### PR TITLE
Install docker-sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM docker
 LABEL maintainer "@flemay"
-RUN apk add --update make zip git curl openssl py-pip bash
+RUN apk add --update make zip git curl openssl py-pip bash ruby ruby-dev ruby-json
 RUN pip install --upgrade pip docker-compose
+RUN gem install --no-ri --no-rdoc docker-sync
 CMD [ "make" ]

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 	docker build --no-cache -t $(IMAGE_NAME) .
 .PHONY: build
 
-test:
+test: envfile
 	$(COMPOSE_RUN_ENVVARS) validate
 	$(DOCKER_RUN_MUSKETEERS) make --version
 	$(DOCKER_RUN_MUSKETEERS) zip --version
@@ -37,6 +37,7 @@ test:
 	$(DOCKER_RUN_MUSKETEERS) docker --version
 	$(DOCKER_RUN_MUSKETEERS) docker-compose --version
 	$(DOCKER_RUN_MUSKETEERS) bash --version
+	$(DOCKER_RUN_MUSKETEERS) docker-sync --version
 .PHONY: test
 
 shell:


### PR DESCRIPTION
As per documentation here http://3musketeers.io/docs#docker-development-is-slow, `docker-sync` may be used to speed up performance on OSX/Windows. 

Therefore it would make sense to include `docker-sync` into docker-musketeers so that development environments all share a common consistent interface. 

This PR will allow for a the default linux (native) sync strategy. But it would also be worth while considering whether unison should be included in the future